### PR TITLE
Add Cloudflare Pages preview workflow for PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,43 @@
+name: Preview (Cloudflare Pages)
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build site
+        run: pnpm build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist/ --project-name=frcsoftware
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,43 +1,43 @@
 name: Preview (Cloudflare Pages)
 
 on:
-  pull_request:
-    branches: [main]
+    pull_request:
+        branches: [main]
 
 concurrency:
-  group: preview-${{ github.ref }}
-  cancel-in-progress: true
+    group: preview-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  deploy-preview:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      deployments: write
-    steps:
-      - uses: actions/checkout@v5
+    deploy-preview:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            deployments: write
+        steps:
+            - uses: actions/checkout@v5
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.16.0
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10.16.0
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+                  cache: pnpm
 
-      - name: Install dependencies
-        run: pnpm install
+            - name: Install dependencies
+              run: pnpm install
 
-      - name: Build site
-        run: pnpm build
+            - name: Build site
+              run: pnpm build
 
-      - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist/ --project-name=frcsoftware
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+            - name: Deploy to Cloudflare Pages
+              uses: cloudflare/wrangler-action@v3
+              with:
+                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  command: pages deploy dist/ --project-name=frcsoftware
+                  gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,11 +1,11 @@
 name: Preview (Cloudflare Pages)
 
 on:
-    pull_request:
+    pull_request_target:
         branches: [main]
 
 concurrency:
-    group: preview-${{ github.ref }}
+    group: preview-${{ github.event.number }}
     cancel-in-progress: true
 
 jobs:
@@ -14,8 +14,12 @@ jobs:
         permissions:
             contents: read
             deployments: write
+            pull-requests: write
         steps:
             - uses: actions/checkout@v5
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
+                  repository: ${{ github.event.pull_request.head.repo.full_name }}
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4


### PR DESCRIPTION
Deploys PR previews to Cloudflare Pages using `cloudflare/wrangler-action`.

Requires two repository secrets:
- `CLOUDFLARE_API_TOKEN` — API token with Pages:Edit permission
- `CLOUDFLARE_ACCOUNT_ID` — your Cloudflare account ID

Also needs the Cloudflare Pages project `frcsoftware` to exist (create via Workers & Pages → Create → Pages, then skip Git setup).