### PR TITLE
Fix code region validation

### DIFF
--- a/scripts/validate-regions.ts
+++ b/scripts/validate-regions.ts
@@ -8,7 +8,7 @@ const DOCS_DIR = join(ROOT, 'src', 'content', 'docs');
 
 const START_RE = /^\s*(?:\/\/|#|--|<!--|-->)?\s*\[(\w+)\]\s*$/;
 const END_RE = /^\s*(?:\/\/|#|--|<!--|-->)?\s*\[\/(\w+)\]\s*$/;
-const CODEBLOCK_RE = /```\w+\s+(\S+)#(\w+)/;
+const CODEBLOCK_RE = /^\s*```\w+\s+(\S+)#(\w+)/;
 
 const errors: string[] = [];
 

--- a/scripts/validate-regions.ts
+++ b/scripts/validate-regions.ts
@@ -8,7 +8,7 @@ const DOCS_DIR = join(ROOT, 'src', 'content', 'docs');
 
 const START_RE = /^\s*(?:\/\/|#|--|<!--|-->)?\s*\[(\w+)\]\s*$/;
 const END_RE = /^\s*(?:\/\/|#|--|<!--|-->)?\s*\[\/(\w+)\]\s*$/;
-const CODEBLOCK_RE = /^```\w+\s+(\S+)#(\w+)/;
+const CODEBLOCK_RE = /```\w+\s+(\S+)#(\w+)/;
 
 const errors: string[] = [];
 


### PR DESCRIPTION
Currently, the codeblock region validation doesn't check if your codeblock is indented in some way (due to being located inside of a `<details>` or `<Aside>` block). For instance, this wouldn't be recognized by the validation script:


\<Aside\>
&nbsp;&nbsp;Lorem Ipsum....
&nbsp;&nbsp;\```java stage0/JavaFundamentals.java#myCodeBlock
&nbsp;&nbsp;
&nbsp;&nbsp;\```
\</Aside\>

Because the triple backticks are indented by 2 spaces.