### PR TITLE
switch copybara to use https instead of ssh

### DIFF
--- a/.github/workflows/copybara.yml
+++ b/.github/workflows/copybara.yml
@@ -39,3 +39,5 @@ jobs:
                   custom_config: copy.bara.sky
                   # Provide the bot's single SSH key for authentication
                   ssh_key: ${{ secrets.COPYBARA_SSH_KEY }}
+                  # Provide the known_hosts signature to prevent MITM false positives
+                  ssh_known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}

--- a/.github/workflows/copybara.yml
+++ b/.github/workflows/copybara.yml
@@ -29,15 +29,16 @@ jobs:
               with:
                   fetch-depth: 0
 
-            # This action automatically pulls the copybara docker image and runs your configuration
-            - name: Run Copybara Action
-              uses: olivr/copybara-action@v1.2.3
-              with:
-                  # This specifies which workflow in your copy.bara.sky file to run
-                  workflow: ${{ matrix.workflow }}
-                  # Path to your config file
-                  custom_config: copy.bara.sky
-                  # Provide the bot's single SSH key for authentication
-                  ssh_key: ${{ secrets.COPYBARA_SSH_KEY }}
-                  # Provide the known_hosts signature to prevent MITM false positives
-                  ssh_known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+            - name: Configure Git Auth
+              run: |
+                  # Configure git to use your PAT for all HTTPS connections to GitHub
+                  git config --global url."https://x-access-token:${{ secrets.COPYBARA_PAT }}@github.com/".insteadOf "https://github.com/"
+
+            - name: Run Copybara via Docker
+              run: |
+                  docker run --rm \
+                    -v ${{ github.workspace }}:/usr/src/app \
+                    -w /usr/src/app \
+                    -v ~/.gitconfig:/root/.gitconfig \
+                    ghcr.io/copybara/copybara:latest \
+                    copybara copy.bara.sky ${{ matrix.workflow }}

--- a/copy.bara.sky
+++ b/copy.bara.sky
@@ -1,16 +1,16 @@
-source_url = "git@github.com:frcsoftware/frcsoftware.git"
+source_url = "https://github.com/frcsoftware/frcsoftware.git"
 
-dest_rev_solution   = "git@github.com:frcsoftware/stage1-rev-solution.git"
-dest_ctre_solution  = "git@github.com:frcsoftware/stage1-ctre-solution.git"
+dest_rev_solution   = "https://github.com/frcsoftware/stage1-rev-solution.git"
+dest_ctre_solution  = "https://github.com/frcsoftware/stage1-ctre-solution.git"
 
 def create_workflow(name, source_path, dest_url):
     core.workflow(
         name = name,
-        origin = git.origin(
+        origin = git.github_origin(
             url = source_url,
             ref = "main",
         ),
-        destination = git.destination(
+        destination = git.github_destination(
             url = dest_url,
             fetch = "main",
             push = "main",


### PR DESCRIPTION
this also switches the workflow to use copybara's docker container directly instead of using the copybara-action workflow that already exists; this is because 
1. the ssh host that the original workflow used was apparently invalid?
2. having a fine grained pat is much safer than using @zachwaffle4-ci's ssh key 