### PR TITLE
Add default code regions

### DIFF
--- a/scripts/validate-regions.ts
+++ b/scripts/validate-regions.ts
@@ -8,7 +8,8 @@ const DOCS_DIR = join(ROOT, 'src', 'content', 'docs');
 
 const START_RE = /^\s*(?:\/\/|#|--|<!--|-->)?\s*\[(\w+)\]\s*$/;
 const END_RE = /^\s*(?:\/\/|#|--|<!--|-->)?\s*\[\/(\w+)\]\s*$/;
-const CODEBLOCK_RE = /^\s*```\w+\s+(\S+)#(\w+)/;
+const CODEBLOCK_RE = /^\s*```\w+\s+(\S*)#(\w+)/;
+const DEFAULT_CODE_REGION_SOURCE_RE = /^---(?:.*\n)*defaultCodeRegionSource:\s*([^\n]+)(?:.*\n)*---$/m;
 
 const errors: string[] = [];
 
@@ -23,10 +24,15 @@ function walkMdx(dir: string) {
             walkMdx(full);
         } else if (entry.name.endsWith('.mdx')) {
             const content = readFileSync(full, 'utf-8');
+            const defaultSource = content.match(DEFAULT_CODE_REGION_SOURCE_RE)?.[1];
             for (const line of content.split('\n')) {
                 const m = line.match(CODEBLOCK_RE);
                 if (m) {
-                    const [, filePath, regionName] = m;
+                    const [, definedFilePath, regionName] = m;
+                    const filePath = definedFilePath || defaultSource;
+                    if (!filePath) {
+                        continue;
+                    }
                     if (!referencedRegions.has(filePath)) {
                         referencedRegions.set(filePath, new Set());
                     }

--- a/scripts/validate-regions.ts
+++ b/scripts/validate-regions.ts
@@ -9,7 +9,8 @@ const DOCS_DIR = join(ROOT, 'src', 'content', 'docs');
 const START_RE = /^\s*(?:\/\/|#|--|<!--|-->)?\s*\[(\w+)\]\s*$/;
 const END_RE = /^\s*(?:\/\/|#|--|<!--|-->)?\s*\[\/(\w+)\]\s*$/;
 const CODEBLOCK_RE = /^\s*```\w+\s+(\S*)#(\w+)/;
-const DEFAULT_CODE_REGION_SOURCE_RE = /^---(?:.*\n)*defaultCodeRegionSource:\s*([^\n]+)(?:.*\n)*---$/m;
+const DEFAULT_CODE_REGION_SOURCE_RE =
+    /^---(?:.*\n)*defaultCodeRegionSource:\s*([^\n]+)(?:.*\n)*---$/m;
 
 const errors: string[] = [];
 
@@ -24,12 +25,20 @@ function walkMdx(dir: string) {
             walkMdx(full);
         } else if (entry.name.endsWith('.mdx')) {
             const content = readFileSync(full, 'utf-8');
-            const defaultSource = content.match(DEFAULT_CODE_REGION_SOURCE_RE)?.[1];
+            const defaultSource = content.match(
+                DEFAULT_CODE_REGION_SOURCE_RE,
+            )?.[1];
             for (const line of content.split('\n')) {
                 const m = line.match(CODEBLOCK_RE);
                 if (m) {
                     const [, definedFilePath, regionName] = m;
                     const filePath = definedFilePath || defaultSource;
+                    if (!filePath) {
+                        errors.push(
+                            `${relative(DOCS_DIR, full)}: Region "${regionName}" has no source file specified`,
+                        );
+                        continue;
+                    }
                     if (!filePath) {
                         continue;
                     }

--- a/src/content/docs/intro-to-java/java-fundamentals.mdx
+++ b/src/content/docs/intro-to-java/java-fundamentals.mdx
@@ -3,6 +3,7 @@ title: Java Fundamentals
 description: An Intro to print statements and variables
 prev: intro-to-java/java-fundamentals
 next: false
+defaultCodeRegionSource: stage0/snippets/JavaFundamentals.java
 ---
 
 ## Syntax
@@ -81,7 +82,7 @@ In FRC, variables can be used to hold information about the robot and its differ
 The example below shows 3 variables that were used for a climber mechanism, CLIMBER_ID is an integer that holds the motor controller ID number which is 51.
 UP_POSITION is a double that holds the value -33.5 and DOWN_POSITION is a double that holds the value 0.
 
-```java stage0/snippets/JavaFundamentals.java#variables
+```java #variables
 
 ```
 
@@ -98,7 +99,7 @@ This can be helpful for making programs that display information to the user or 
 In Java, we can print information to a terminal using a print statement.
 A print statement in Java looks like:
 
-```java stage0/snippets/JavaFundamentals.java#printLiteral
+```java #printLiteral
 
 ```
 
@@ -106,7 +107,7 @@ What the print statement does is take information inside the parentheses, in the
 When using a print statement, the text that we want to print out goes inside the parentheses and is in quotes.
 However, if we are printing out the value of a variable, then we do not need quotes, as shown below.
 
-```java stage0/snippets/JavaFundamentals.java#printVariable
+```java #printVariable
 
 ```
 
@@ -122,13 +123,13 @@ In Java, there are two types of comments: single-line comments and multi-line co
 Single line comments begin with `//` and mark the rest of the line as being a comment.
 For example, the code below leave the note of "This prints out Hello World." above the print statment
 
-```java stage0/snippets/JavaFundamentals.java#singleLineComment
+```java #singleLineComment
 
 ```
 
 You will also see comments placed at the end of a line like the following
 
-```java stage0/snippets/JavaFundamentals.java#inlineComment
+```java #inlineComment
 
 ```
 
@@ -141,6 +142,6 @@ Multi-line Comments start with `/*` and end with `*/` The text or code that is i
 Multi-line Comments are commonly used when you have many lines of text or need to turn a large amount of code into a comment.
 For example, this is a comment with two lines of text
 
-```java stage0/snippets/JavaFundamentals.java#multiLineComment
+```java #multiLineComment
 
 ```

--- a/src/plugins/remark-code-region.ts
+++ b/src/plugins/remark-code-region.ts
@@ -2,10 +2,15 @@ import { visit } from 'unist-util-visit';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import type { Root } from 'mdast';
+import { VFile } from 'vfile';
 
 export default function remarkCodeRegion() {
-    return (tree: Root) => {
+    return (tree: Root, file: VFile) => {
         const examplesDir = resolve(process.cwd(), 'examples');
+        let defaultSource = file.data.astro?.frontmatter?.defaultCodeRegionSource;
+        if (typeof defaultSource !== 'string') {
+            defaultSource = null;
+        }
 
         visit(tree, 'code', (node) => {
             const meta: string = node.meta || '';
@@ -15,7 +20,13 @@ export default function remarkCodeRegion() {
 
             const raw = token[1];
             const hashIdx = raw.indexOf('#');
-            const filePath = hashIdx !== -1 ? raw.slice(0, hashIdx) : raw;
+            const filePath = (() => {
+                switch (hashIdx) {
+                    case -1: return raw;
+                    case 0: return defaultSource;
+                    default: return raw.slice(0, hashIdx);
+                }
+            })();
             const regionName = hashIdx !== -1 ? raw.slice(hashIdx + 1) : null;
 
             node.meta = meta.slice(raw.length).trim();

--- a/src/plugins/remark-code-region.ts
+++ b/src/plugins/remark-code-region.ts
@@ -7,7 +7,8 @@ import { VFile } from 'vfile';
 export default function remarkCodeRegion() {
     return (tree: Root, file: VFile) => {
         const examplesDir = resolve(process.cwd(), 'examples');
-        let defaultSource = file.data.astro?.frontmatter?.defaultCodeRegionSource;
+        let defaultSource =
+            file.data.astro?.frontmatter?.defaultCodeRegionSource;
         if (typeof defaultSource !== 'string') {
             defaultSource = null;
         }
@@ -22,9 +23,12 @@ export default function remarkCodeRegion() {
             const hashIdx = raw.indexOf('#');
             const filePath = (() => {
                 switch (hashIdx) {
-                    case -1: return raw;
-                    case 0: return defaultSource;
-                    default: return raw.slice(0, hashIdx);
+                    case -1:
+                        return raw;
+                    case 0:
+                        return defaultSource;
+                    default:
+                        return raw.slice(0, hashIdx);
                 }
             })();
             const regionName = hashIdx !== -1 ? raw.slice(hashIdx + 1) : null;


### PR DESCRIPTION
Adds the ability to specify a default code region source file in a mdx file's frontmatter:
```
---
title: Writing Commands
defaultCodeRegionSource: stage1/snippets/src/main/java/sources/MySnippetSources.java
---
```

This allows you to exclude the file path in front of the `#` symbol, like so:

<pre>
```java #myCodeBlock

```
</pre>